### PR TITLE
Revamped README

### DIFF
--- a/Kvantum/README.md
+++ b/Kvantum/README.md
@@ -2,30 +2,41 @@
 
 ## Overview
 
-Kvantum (by Pedram Pourang, a.k.a. Tsu Jan <tsujan2000@gmail.com>) is an SVG-based theme engine for Qt, tuned to KDE and LXQt, with an emphasis on elegance, usability and practicality. Its homepage is <https://github.com/tsujan/Kvantum>.
+Kvantum (by [Pedram Pourang, a.k.a. Tsu Jan](#contact)) is an SVG-based theme engine for Qt, tuned to KDE and LXQt, with an emphasis on elegance, usability and practicality.
 
 Kvantum has a default dark theme, which is inspired by the default theme of Enlightenment. Creation of realistic themes like that for KDE was my first reason to make Kvantum but it goes far beyond its default theme: you could make themes with very different looks and feels for it, whether they be photorealistic or cartoonish, 3D or flat, embellished or minimalistic, or something in between, and Kvantum will let you control almost every aspect of Qt widgets.
 
 Kvantum also comes with extra themes that are installed as root with Qt5 installation and can be selected and activated by using Kvantum Manager.
 
-Please see INSTALL for instructions on compilation, installation and usage!
+## Installation and usage
 
-For instructions on how to change configuration or make new themes, read the files Theme-Config and Theme-Making in the "doc" folder!
+See [INSTALL](INSTALL.md) for instructions on how to compile, install and use Kvantum.
 
+### Configuring themes
+
+See [Theme-Config](doc/Theme-Config) for instructions on how to install and configure themes.
+
+### Theme making
+
+See [Theme-Making](doc/Theme-Making) for instructions on how to create themes.
+
+## Contact
+
+You can contact me at <tsujan2000@gmail.com>.
 
 ## Credits:
 
-The core idea of Kvantum, namely using of SVG images for drawing Qt widgets, was taken from QuantumStyle (not developed anymore but continued as QSvgStyle at https://github.com/DexterMagnific/QSvgStyle).
+The core idea of Kvantum, namely using of SVG images for drawing Qt widgets, was taken from QuantumStyle (not developed anymore but continued as [QSvgStyle](https://github.com/DexterMagnific/QSvgStyle)).
 
 Some code parts are adapted from:
 
-QtCurve (https://projects.kde.org/projects/playground/artwork/qtcurve/repository)
+[QtCurve](https://projects.kde.org/projects/playground/artwork/qtcurve/repository)
 
-Oxygen (https://projects.kde.org/projects/playground/artwork/oxygen/repository)
+[Oxygen](https://projects.kde.org/projects/playground/artwork/oxygen/repository)
 
-Oxygen-Transparent (https://projects.kde.org/projects/playground/artwork/oxygen-transparent/repository)
+[Oxygen-Transparent](https://projects.kde.org/projects/playground/artwork/oxygen-transparent/repository)
 
-Bespin (http://cloudcity.sourceforge.net/download.php)
+[Bespin](http://cloudcity.sourceforge.net/download.php)
 
 My sincerest thanks go to all users whose bug reports, feature requests and suggestions have been crucial for improving Kvantum.
 


### PR DESCRIPTION
- Created #contacts to plug your Gmail and href'ed it, because it was irrelevant to #overview and it took too much space.
- Removed "Its homepage is https://github.com/tsujan/Kvantum." because it seemed pointless and once again, it took too much space.
- Created #installation-and-usage for simplicity purposes.
- Created #configuring-themes and #theme-making for properly categorise them.
- href'ed INSTALL, Theme-Config and Theme-Config, because this whole category seemed half-assed and was difficult to navigate.
- Line 7 was descriptive and was well written altogether; good job for that (decided to do some feeback too :) ).
- href'ed the stuff from "Some code parts are adapted from" because again, too much space.